### PR TITLE
feat(#14 tasks): Auto-scroll to keep new tasks in viewport when addin…

### DIFF
--- a/src/components/tasks.tsx
+++ b/src/components/tasks.tsx
@@ -149,6 +149,10 @@ export function TasksCard() {
     }),
   );
 
+  useEffect(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  }, [input]);
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {


### PR DESCRIPTION
The pull request addresses an issue where newly added tasks can end up outside the viewport. To enhance user experience, a useEffect hook has been added at line 152 to automatically scroll to the bottom of the page whenever a new task is added, ensuring that the new task remains in view.